### PR TITLE
Add memory manager logging and assignment demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project provides a simple yet powerful example of how multiple LLM agents c
 - **Custom Validation:** Agents can use custom functions (like `custom_validate`) to ensure that outputs meet certain criteria.
 - **Custom LLM Functions:** Agents can override the default LLM logic with functions like `custom_llm_fn` to implement specialized behavior.
 - **Flexible Configuration:** Easily adjust model parameters, prompts, and the workflow structure to fit your use case.
+- **Evolution Logging:** The optional `MemoryManager` records each evolution step for later analysis.
 
 ## Project Structure
 

--- a/assignment.py
+++ b/assignment.py
@@ -1,0 +1,18 @@
+"""Simple agent and tool assignment step."""
+
+from task import Task
+
+
+def assign_agents_and_tools(task_list, tool_registry=None):
+    """Assign default agent types and tool sequences to each task."""
+    available_tools = set(tool_registry or [])
+    for task in task_list:
+        # Assign a generic agent type
+        task.agent_type = task.agent_type or "llm"
+        # naive tool assignment based on keywords
+        desc = task.description.lower()
+        if "code" in desc and "exec" in available_tools:
+            task.pre_tools.append("exec")
+        if "echo" in available_tools:
+            task.post_tools.append("echo")
+    return task_list

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ from mcst_executor import MCSTExecutor
 from evolver import EvolverAgent
 from evaluator import EvaluatorAgent
 from judge import JudgeAgent
+from assignment import assign_agents_and_tools
+from memory_manager import MemoryManager
 
 
 def build_workflow_manager():
@@ -61,6 +63,12 @@ def run_demo(user_prompt, interactive=False, user_input_fn=None):
         first_lines = [next(f).strip() for _ in range(10)]
     print("\nLoaded task list excerpt:\n" + "\n".join(first_lines))
 
+    # Demonstrate agent and tool assignment
+    demo_tasks = [Task(description="Generate sample code"), Task(description="Echo hello")]
+    assign_agents_and_tools(demo_tasks, manager.tool_manager._tools.keys())
+    for t in demo_tasks:
+        print(f"Assigned to {t.agent_type} with pre {t.pre_tools} and post {t.post_tools}")
+
     # Simple MCST demonstration
     model_config = {
         "model": "llama3.2:latest",
@@ -75,7 +83,8 @@ def run_demo(user_prompt, interactive=False, user_input_fn=None):
     task = Task(description="simple evolution task", pre_tools=["echo"], post_tools=["upper"])
     base_agent = EvolvingAgent(name="base", model_config=model_config, prompt="say hi", code="print('hi')")
     executor = MCSTExecutor(branching_factor=2, max_depth=1)
-    best = executor.run(task, base_agent, evolver, evaluator, judge)
+    memory_manager = MemoryManager()
+    best = executor.run(task, base_agent, evolver, evaluator, judge, memory_manager)
     print(f"Best version: {best.version}")
 
 

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -9,9 +9,13 @@ class MemoryManager:
                 json.dump([], f)
 
     def add_evolution(self, branch_id, parent_id, code, prompt, tool, score, rationale):
+        """Persist a single evolution step to the log file."""
         entry = {
             "branch_id": branch_id,
             "parent_id": parent_id,
+            "code": code,
+            "prompt": prompt,
+            "tool": tool,
             "score": score,
             "rationale": rationale,
         }

--- a/mock_ollama.py
+++ b/mock_ollama.py
@@ -1,5 +1,3 @@
-import json
-
 def chat(model, messages, stream=False, options=None):
     """Return a mock response mimicking `ollama.chat`."""
     last_user = next((m['content'] for m in reversed(messages) if m.get('role') == 'user'), '')


### PR DESCRIPTION
## Summary
- add simple `assign_agents_and_tools` step
- integrate `MemoryManager` with `MCSTExecutor`
- demonstrate assignment and logging in `main.py`
- document evolution logging in README
- clean up unused import

## Testing
- `pyflakes *.py tools/*.py`
- `python -m py_compile $(git ls-files '*.py')`
- `MOCK_OLLAMA=1 python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6846280e0e048324915d82535932f0ab